### PR TITLE
Make user prompt password hidden in terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "once_cell",
  "rand",
  "ring",
+ "rpassword",
  "serde",
  "serde-encrypt",
  "thiserror",
@@ -863,6 +864,27 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "winapi",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ colour = "0.7.0"
 once_cell = "1.18.0"
 rand = "0.8.5"
 ring = "0.17.5"
+rpassword = "7.2.0"
 serde = { version = "1.0.189", features = ["derive"] }
 serde-encrypt = "0.7.0"
 thiserror = "1.0.49"

--- a/src/pass/entry.rs
+++ b/src/pass/entry.rs
@@ -11,7 +11,7 @@ impl Password {
     pub fn new(password: Option<impl AsRef<[u8]>>) -> Self {
         let pass = match password {
             Some(pass) => pass.as_ref().to_vec(),
-            None => generate_random_password(12).as_ref().to_vec(),
+            None => generate_random_password(12).as_ref().as_bytes().to_vec(),
         };
 
         Password { password: pass }

--- a/src/pass/master.rs
+++ b/src/pass/master.rs
@@ -105,11 +105,10 @@ impl MasterPassword<Uninit> {
 
     pub fn password_input() -> Result<impl AsRef<str>, MasterPasswordError> {
         colour::green!("Enter Master password: ");
-        let mut master_password = String::new();
-        std::io::stdin()
-            .read_line(&mut master_password)
-            .map_err(|e| MasterPasswordError::UnableToReadFromConsole(e))?;
-        Ok(master_password.trim().to_owned())
+        let master_password =
+            rpassword::read_password().map_err(MasterPasswordError::UnableToReadFromConsole)?;
+
+        Ok(master_password.to_owned())
     }
 
     // Check if master password is correct
@@ -179,9 +178,8 @@ impl MasterPassword<Unlocked> {
     pub fn change(&mut self) -> Result<(), MasterPasswordError> {
         let mut password = String::new();
         colour::green!("Enter new master password: ");
-        std::io::stdin()
-            .read_line(&mut password)
-            .map_err(|e| MasterPasswordError::UnableToReadFromConsole(e))?;
+        let password =
+            rpassword::read_password().map_err(MasterPasswordError::UnableToReadFromConsole)?;
 
         if is_strong_password(&password) {
             let password = password.trim();

--- a/src/pass/util.rs
+++ b/src/pass/util.rs
@@ -81,7 +81,7 @@ pub fn is_strong_password(password: impl AsRef<str>) -> bool {
 }
 
 // Generate random password of given length
-pub fn generate_random_password(length: u8) -> impl AsRef<[u8]> {
+pub fn generate_random_password(length: u8) -> impl AsRef<str> {
     use rand::Rng;
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                         abcdefghijklmnopqrstuvwxyz\


### PR DESCRIPTION
### What does this PR for?
Add [rpassword](https://crates.io/crates/rpassword) to hide user prompt password from terminal

### What does this PR solve?
- Fix #9 by adding [rpassword](https://crates.io/crates/rpassword)
- Fix minor bugs in `gen` & `change-master` commands